### PR TITLE
Add AI tool directories with README guides

### DIFF
--- a/CapCut/README.md
+++ b/CapCut/README.md
@@ -1,0 +1,17 @@
+# CapCut
+
+## Giới thiệu công cụ
+CapCut là phần mềm chỉnh sửa video trực quan với nhiều hiệu ứng sẵn có, cho phép tạo video marketing hấp dẫn mà không đòi hỏi kỹ năng chuyên sâu.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Sản xuất video quảng cáo ngắn
+- Biên tập video hướng dẫn sản phẩm
+- Tạo nội dung mạng xã hội sinh động
+
+## Gợi ý sử dụng thực tế
+- Sử dụng kho template để dựng video nhanh
+- Kết hợp với Midjourney để chèn hình ảnh AI độc đáo
+- Đăng tải trực tiếp lên các nền tảng mạng xã hội
+
+## Link tài liệu hoặc demo
+- [Trang chủ CapCut](#) *(đang cập nhật)*

--- a/ChatGPT/README.md
+++ b/ChatGPT/README.md
@@ -1,0 +1,17 @@
+# ChatGPT
+
+## Giới thiệu công cụ
+ChatGPT là trợ lý AI do OpenAI phát triển, có khả năng hiểu và tạo văn bản tự nhiên. Công cụ này giúp người dùng giao tiếp với máy tính bằng ngôn ngữ hằng ngày.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Trả lời câu hỏi khách hàng 24/7
+- Hỗ trợ soạn thảo email, bài viết marketing
+- Tổng hợp thông tin nhanh chóng cho nhóm nội bộ
+
+## Gợi ý sử dụng thực tế
+- Tạo mẫu phản hồi cho dịch vụ khách hàng
+- Viết kịch bản chatbot trên website
+- Lên ý tưởng nội dung cho mạng xã hội
+
+## Link tài liệu hoặc demo
+- [Tài liệu hướng dẫn](#) *(đang cập nhật)*

--- a/ClickUp/README.md
+++ b/ClickUp/README.md
@@ -1,0 +1,17 @@
+# ClickUp
+
+## Giới thiệu công cụ
+ClickUp là nền tảng quản lý công việc và dự án, cho phép giao việc, theo dõi tiến độ và phối hợp nhóm hiệu quả trên một giao diện thống nhất.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Quản lý dự án marketing hoặc phát triển sản phẩm
+- Theo dõi công việc của từng phòng ban
+- Lưu trữ tài liệu và trao đổi thông tin tập trung
+
+## Gợi ý sử dụng thực tế
+- Tạo bảng Kanban cho từng chiến dịch
+- Sử dụng tính năng tự động nhắc nhở deadline
+- Kết hợp với GPT Builder để xây chatbot hỗ trợ nội bộ
+
+## Link tài liệu hoặc demo
+- [Website ClickUp](#) *(đang cập nhật)*

--- a/ElevenLabs/README.md
+++ b/ElevenLabs/README.md
@@ -1,0 +1,17 @@
+# ElevenLabs
+
+## Giới thiệu công cụ
+ElevenLabs cung cấp dịch vụ chuyển văn bản thành giọng nói tự nhiên, hỗ trợ nhiều ngôn ngữ với chất lượng cao, phù hợp cho video thuyết minh và trợ lý ảo.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Tạo video giới thiệu sản phẩm với giọng đọc chuyên nghiệp
+- Xây dựng hệ thống tổng đài tự động
+- Làm sách nói hoặc nội dung e-learning
+
+## Gợi ý sử dụng thực tế
+- Chọn giọng đọc phù hợp với thương hiệu
+- Sử dụng cho chatbot voice hoặc ứng dụng di động
+- Phối hợp cùng Runway để thêm thuyết minh cho video
+
+## Link tài liệu hoặc demo
+- [Trang ElevenLabs](#) *(đang cập nhật)*

--- a/GPT Builder/README.md
+++ b/GPT Builder/README.md
@@ -1,0 +1,17 @@
+# GPT Builder
+
+## Giới thiệu công cụ
+GPT Builder là nền tảng giúp doanh nghiệp tùy chỉnh mô hình GPT theo nhu cầu, dễ dàng tạo chatbot hoặc trợ lý ảo chuyên biệt cho từng nghiệp vụ.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Xây dựng chatbot chăm sóc khách hàng
+- Tạo hệ thống trả lời tự động cho nhân viên
+- Cá nhân hóa quy trình tư vấn bán hàng
+
+## Gợi ý sử dụng thực tế
+- Thu thập các câu hỏi thường gặp để huấn luyện mô hình
+- Kết hợp ClickUp theo dõi yêu cầu người dùng
+- Triển khai trên website hoặc ứng dụng nội bộ
+
+## Link tài liệu hoặc demo
+- [Tài liệu GPT Builder](#) *(đang cập nhật)*

--- a/Gamma/README.md
+++ b/Gamma/README.md
@@ -1,0 +1,17 @@
+# Gamma
+
+## Giới thiệu công cụ
+Gamma giúp tạo slide thuyết trình tự động dựa trên AI, hỗ trợ người dùng thiết kế nội dung rõ ràng và hình ảnh minh họa hấp dẫn chỉ trong vài bước.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Chuẩn bị bài thuyết trình bán hàng
+- Tạo slide đào tạo nội bộ nhanh chóng
+- Nâng cao tính chuyên nghiệp khi trình bày với đối tác
+
+## Gợi ý sử dụng thực tế
+- Sử dụng mẫu có sẵn để tiết kiệm thời gian
+- Chèn hình ảnh AI vào bài thuyết trình marketing
+- Kết hợp với CapCut để dựng video giới thiệu từ slide
+
+## Link tài liệu hoặc demo
+- [Video demo](#) *(đang cập nhật)*

--- a/Midjourney/README.md
+++ b/Midjourney/README.md
@@ -1,0 +1,17 @@
+# Midjourney
+
+## Giới thiệu công cụ
+Midjourney là ứng dụng tạo hình ảnh bằng AI từ mô tả văn bản, cho phép doanh nghiệp có được hình minh họa độc đáo cho chiến dịch truyền thông mà không cần thuê thiết kế.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Sản xuất hình ảnh quảng cáo sáng tạo
+- Làm poster, banner cho mạng xã hội
+- Hỗ trợ ý tưởng thiết kế sản phẩm mới
+
+## Gợi ý sử dụng thực tế
+- Thử nhiều mô tả khác nhau để có kết quả đa dạng
+- Kết hợp với CapCut hoặc Runway để tạo video
+- Lưu trữ thư viện ảnh cho các chiến dịch dài hạn
+
+## Link tài liệu hoặc demo
+- [Gallery Midjourney](#) *(đang cập nhật)*

--- a/Perplexity/README.md
+++ b/Perplexity/README.md
@@ -1,0 +1,17 @@
+# Perplexity
+
+## Giới thiệu công cụ
+Perplexity là công cụ tìm kiếm kết hợp AI, cung cấp câu trả lời chính xác và trích dẫn nguồn rõ ràng, giúp người dùng tiết kiệm thời gian khi nghiên cứu thông tin.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Tìm kiếm xu hướng thị trường, đối thủ cạnh tranh
+- Thu thập dữ liệu để viết báo cáo nhanh
+- Hỗ trợ nhân viên cập nhật kiến thức chuyên ngành
+
+## Gợi ý sử dụng thực tế
+- Sử dụng mục nguồn tham khảo để kiểm chứng thông tin
+- Kết hợp ChatGPT để khai thác sâu hơn các chủ đề
+- Lưu lại các kết quả quan trọng vào ClickUp
+
+## Link tài liệu hoặc demo
+- [Tham khảo Perplexity](#) *(đang cập nhật)*

--- a/Runway/README.md
+++ b/Runway/README.md
@@ -1,0 +1,17 @@
+# Runway
+
+## Giới thiệu công cụ
+Runway mang đến các tính năng xử lý video bằng AI như tách nền, tạo hiệu ứng và chỉnh sửa nhanh chóng, hỗ trợ sản xuất nội dung chuyên nghiệp hơn.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Làm video quảng cáo sáng tạo
+- Cắt ghép, chỉnh sửa clip đào tạo nội bộ
+- Xử lý hậu kỳ cho video bán hàng
+
+## Gợi ý sử dụng thực tế
+- Dùng tính năng remove background để làm nổi bật sản phẩm
+- Kết hợp CapCut trong quá trình chỉnh sửa cuối cùng
+- Xuất video chất lượng cao sẵn sàng đăng tải
+
+## Link tài liệu hoặc demo
+- [Hướng dẫn Runway](#) *(đang cập nhật)*

--- a/Sora/README.md
+++ b/Sora/README.md
@@ -1,0 +1,17 @@
+# Sora
+
+## Giới thiệu công cụ
+Sora cho phép tạo video từ văn bản, biến nội dung viết thành clip sinh động để giới thiệu sản phẩm hoặc hướng dẫn sử dụng một cách trực quan.
+
+## Ứng dụng trong doanh nghiệp vừa và nhỏ
+- Sản xuất video quảng bá dịch vụ nhanh chóng
+- Tạo nội dung đào tạo trực tuyến
+- Đa dạng hóa kênh truyền thông cho thương hiệu
+
+## Gợi ý sử dụng thực tế
+- Viết kịch bản ngắn gọn trước khi tạo video
+- Kết hợp ElevenLabs để thêm giọng đọc tự nhiên
+- Chỉnh sửa thêm bằng CapCut hoặc Runway nếu cần
+
+## Link tài liệu hoặc demo
+- [Demo Sora](#) *(đang cập nhật)*


### PR DESCRIPTION
## Summary
- add folders for ChatGPT, Gamma, CapCut, ClickUp, Runway, ElevenLabs, Midjourney, Perplexity, GPT Builder and Sora
- each folder contains a Vietnamese README with intro, business use cases, practical tips and placeholder links

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fb89cf0688320917f365506e5f5fa